### PR TITLE
Fix incorrect coordinates in weather hooks

### DIFF
--- a/src/hooks/LondonDailyWeather.js
+++ b/src/hooks/LondonDailyWeather.js
@@ -7,7 +7,7 @@ export const useGetLondonDailyWeather = () => {
     if (!londonDailyWeather) {
       axios
         .get(
-          "https://api.open-meteo.com/v1/forecast?latitude=52.52&longitude=13.41&daily=temperature_2m_max,temperature_2m_min&timezone=Europe%2FLondon&forecast_days=16"
+          "https://api.open-meteo.com/v1/forecast?latitude=51.50&longitude=-0.12&daily=temperature_2m_max,temperature_2m_min&timezone=Europe%2FLondon&forecast_days=16"
         )
         .then(function (response) {
           setLondonWeather(response.data.daily)

--- a/src/hooks/LosAngelesCurrentWeather.js
+++ b/src/hooks/LosAngelesCurrentWeather.js
@@ -7,7 +7,7 @@ export const useGetLosAngelesCurrentWeather = () => {
         if (!losAngelesCurrentWeather) {
             axios
                 .get(
-                    "https://api.open-meteo.com/v1/forecast?latitude=34.05&longitude=118.25&current=temperature_2m&timezone=America%2FLos_Angeles"
+                    "https://api.open-meteo.com/v1/forecast?latitude=34.05&longitude=-118.25&current=temperature_2m&timezone=America%2FLos_Angeles"
                 )
                 .then(function (response) {
                     setLosAngelesCurrentWeather(response.data.current)

--- a/src/hooks/LosAngelesDailyWeather.js
+++ b/src/hooks/LosAngelesDailyWeather.js
@@ -7,7 +7,7 @@ export const useGetLosAngelesDailyWeather = () => {
         if (!losAngelesDailyWeather) {
             axios
                 .get(
-                    "https://api.open-meteo.com/v1/forecast?latitude=34.05&longitude=118.2426&daily=temperature_2m_max,temperature_2m_min&timezone=Europe%2FBerlin&forecast_days=16"
+                    "https://api.open-meteo.com/v1/forecast?latitude=34.05&longitude=-118.2426&daily=temperature_2m_max,temperature_2m_min&timezone=Europe%2FBerlin&forecast_days=16"
                 )
                 .then(function (response) {
                     setLosAngelesWeather(response.data.daily)


### PR DESCRIPTION
## Summary
- correct Los Angeles coordinates for current and daily weather hooks
- correct London coordinates for daily weather hook

## Testing
- `npm test --silent -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684053c2527c8333bd168f578bea7b44