### PR TITLE
Fix toggle button CSS

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -57,7 +57,6 @@
 
 .toggle-btn:hover {
   background-color: var(--primary-dark-color);
-  ;
 }
 
 .toggle-btn:focus {

--- a/src/pages/styles/Home.module.css
+++ b/src/pages/styles/Home.module.css
@@ -57,7 +57,6 @@
 
 .toggle-btn:hover {
     background-color: var(--primary-dark-color);
-    ;
 }
 
 .toggle-btn:focus {

--- a/src/pages/styles/London16DaysWeather.module.css
+++ b/src/pages/styles/London16DaysWeather.module.css
@@ -8,7 +8,6 @@
 
 .toggle-btn:hover {
     background-color: var(--primary-dark-color);
-    ;
 }
 
 .toggle-btn:focus {

--- a/src/pages/styles/LosAngeles16DaysWeather.module.css
+++ b/src/pages/styles/LosAngeles16DaysWeather.module.css
@@ -8,7 +8,6 @@
 
 .toggle-btn:hover {
     background-color: var(--primary-dark-color);
-    ;
 }
 
 .toggle-btn:focus {


### PR DESCRIPTION
## Summary
- remove stray semicolons from `.toggle-btn:hover` selectors

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684055534dec83338a286ed1b7800b6b